### PR TITLE
fix: add missing encoder compatible

### DIFF
--- a/config/moNa2.json
+++ b/config/moNa2.json
@@ -63,6 +63,7 @@
       "ref": "right_encoder",
       "name": "encoder_right",
       "identifier": "encoder_right",
+      "compatible": "alps,ec11",
       "enabled": false
     }
   ]


### PR DESCRIPTION
## Summary
- specify `compatible` property for right encoder in layout JSON

## Testing
- `jq . config/moNa2.json`


------
https://chatgpt.com/codex/tasks/task_e_68a2b5fef6fc832eaf86eff587ca62fa